### PR TITLE
Fixed clang error

### DIFF
--- a/src/lib/simpleio/main.c
+++ b/src/lib/simpleio/main.c
@@ -126,7 +126,7 @@ outn (long n)
 {
     if (n < 0) {
         out ('-');
-        n = abs (n);
+        n = labs (n);
     }
     outnu (n);
 }


### PR DESCRIPTION
main.c:129:13: error: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Werror,-Wabsolute-value]
  129 |         n = abs (n);
      |             ^
main.c:129:13: note: use function 'labs' instead
  129 |         n = abs (n);
      |             ^~~
      |             labs
1 error generated.